### PR TITLE
Add bloop to lila-ws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ logs/
 target/
 project/metals.sbt
 project/project
+project/.bloop
+.bloop
+.metals
+.vscode

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"        % "2.4.2")
+addSbtPlugin("ch.epfl.scala"     % "sbt-bloop"    % "1.4.8")


### PR DESCRIPTION
Per [this conversation on Discord](https://discord.com/channels/280713822073913354/693123750845218836/828179553586380820), I've added `bloopInstall` to this repo, just like the lila repo. Tested, and bloop now works with this repo.