### PR TITLE
Send spectator changes to anon only rooms

### DIFF
--- a/src/main/scala/ipc/CrowdJson.scala
+++ b/src/main/scala/ipc/CrowdJson.scala
@@ -34,7 +34,7 @@ final class CrowdJson(
             "white" -> (crowd.players.white > 0),
             "black" -> (crowd.players.black > 0)
           )
-          .add("watchers" -> (if (crowd.room.users.nonEmpty) Some(spectators) else None))
+          .add("watchers" -> Some(spectators))
       )
     }
 


### PR DESCRIPTION
Not sure whether this is intentional but since this works in studies and I was already looking at it I figured I should at least bring it up.

To see how this is currently not working, open a past game with multiple anon users. You will not get any info about spectators unless at least one non-anon user joins.